### PR TITLE
[Feature] Universal Upgrader (#2)

### DIFF
--- a/Content.Server/_Ataraxia/UniversalUpgrader/Components/UPComponent.cs
+++ b/Content.Server/_Ataraxia/UniversalUpgrader/Components/UPComponent.cs
@@ -1,0 +1,21 @@
+
+namespace Content.Server._Ataraxia.UniversalUpgrader.Components;
+
+[RegisterComponent]
+public sealed partial class UPComponent : Component
+{
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string upgradeName;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string componentName;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float upgradeValue;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string ProtoWhitelist;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public int usable = 0;
+}

--- a/Content.Server/_Ataraxia/UniversalUpgrader/Systems/UPSystem.cs
+++ b/Content.Server/_Ataraxia/UniversalUpgrader/Systems/UPSystem.cs
@@ -1,0 +1,48 @@
+
+using Content.Server._Ataraxia.UniversalUpgrader.Components;
+using Content.Shared.Interaction;
+
+namespace Content.Server._Ataraxia.UniversalUpgrader.Systems;
+
+public sealed class UPSystem  : EntitySystem
+{
+
+    [Dependency] private readonly EntityManager _ent = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<UPComponent, AfterInteractEvent>(OnInteract);
+    }
+
+    private void OnInteract(Entity<UPComponent> entity, ref AfterInteractEvent args)
+    {
+        if (!args.CanReach || args.Target is not { Valid: true } target)
+            return;
+        if (entity.Comp.ProtoWhitelist != null && HasComp<MetaDataComponent>(target))
+        {
+            var z = _ent.GetComponent<MetaDataComponent>(target);
+            if (z.EntityPrototype!.ID != entity.Comp.ProtoWhitelist)
+                return;
+        }
+
+        Type? g = Type.GetType(entity.Comp.componentName);
+
+        if (g != null && _ent.TryGetComponent(target, g, out var comp))
+        {
+
+            var h = comp.GetType().GetField(entity.Comp.upgradeName);
+
+            if (h != null)
+            {
+
+                if (h.FieldType == typeof(int)) h.SetValue(comp,(int) entity.Comp.upgradeValue);
+                if (h.FieldType == typeof(float)) h.SetValue(comp,(int) entity.Comp.upgradeValue);
+
+            }
+            entity.Comp.usable -= 1;
+            if (entity.Comp.usable < 0) _ent.QueueDeleteEntity(entity);
+
+        }
+    }
+
+}

--- a/Resources/Prototypes/_Ataraxia/UPtest.yml
+++ b/Resources/Prototypes/_Ataraxia/UPtest.yml
@@ -1,0 +1,27 @@
+- type: entity
+  parent: BaseItem
+  id: UPRcd
+  name: UPTestRCD
+  description: UP
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/skub.rsi
+    state: icon
+  - type: Tag
+    tags:
+      - Payload
+  - type: Item
+    sprite: Objects/Misc/skub.rsi
+  - type: EmitSoundOnUse
+    sound:
+      collection: Skub
+  - type: EmitSoundOnTrigger
+    sound:
+      collection: Skub
+  - type: UseDelay
+    delay: 2.0
+  - type: UP
+    componentName: "Content.Shared.Charges.Components.LimitedChargesComponent, Content.Shared"
+    upgradeName: "MaxCharges"
+    upgradeValue: 60
+    protoWhitelist: "RCD"


### PR DESCRIPTION
Осталось доделать 2 вещи.
[] Добавить возможность установить DoAfter
[] Перевести значение в string и накодить его перевод в другие типы , что позволит изменять в будущем следующие значение: int, float, bool, string и возможно list/dict.
